### PR TITLE
Map features for BCNs

### DIFF
--- a/client/src/components/MapPane.jsx
+++ b/client/src/components/MapPane.jsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { useSelector } from 'react-redux'
 
-import { XIcon, BadgeCheckIcon, XCircleIcon, ArrowsExpandIcon } from '@heroicons/react/outline'
+import { XIcon, BadgeCheckIcon } from '@heroicons/react/outline'
 import { useDispatch } from 'react-redux'
 
 // Lightbox
-import { SRLWrapper } from 'simple-react-lightbox';
 import { useMap } from '@monsonjeremy/react-leaflet';
 import { useEffect } from 'react';
 

--- a/client/src/components/map/DoneBcnsLayer.jsx
+++ b/client/src/components/map/DoneBcnsLayer.jsx
@@ -1,0 +1,35 @@
+import {useSelector } from "react-redux";
+import { LayerGroup } from "@monsonjeremy/react-leaflet";
+
+import { Marker, Popup } from "@monsonjeremy/react-leaflet";
+
+import {getIcon} from "./DoneLayer";
+
+/**
+ * Displays all done bcns
+ */
+export default function DoneBcnsLayer(props) {
+    const bcns = useSelector(state => state.bcns);
+
+    function handleInfoClick (e) {
+        window.location.hash = `#map/${e.target.attributes["data-city"].value}`;
+    }
+
+    return (
+        <LayerGroup>
+            {bcns.map(bcn => {
+                const icon = getIcon(bcn);
+
+                return (
+                    <Marker position={[bcn.city_lat, bcn.city_long]} icon={icon} key={bcn.bcn_id}>
+                        <Popup>
+                            {`${bcn.city_name} (${bcn.city_departement})`}<br />
+                            Validé le : {new Date(bcn.bcn_date).toLocaleDateString()}<br/>
+                            <span className="underline text-blue-600 cursor-pointer" data-city={bcn.city_poi_id} onClick={handleInfoClick}>Plus d'infos</span>
+                        </Popup>
+                    </Marker>
+                )
+            })}
+        </LayerGroup>
+    )
+}

--- a/client/src/components/map/DoneBcnsLayer.jsx
+++ b/client/src/components/map/DoneBcnsLayer.jsx
@@ -24,7 +24,7 @@ export default function DoneBcnsLayer(props) {
                     <Marker position={[bcn.city_lat, bcn.city_long]} icon={icon} key={bcn.bcn_id}>
                         <Popup>
                             {`${bcn.city_name} (${bcn.city_departement})`}<br />
-                            Validé le : {new Date(bcn.bcn_date).toLocaleDateString()}<br/>
+                            Validé le : {new Date(bcn.bpf_date).toLocaleDateString()}<br/>
                             <span className="underline text-blue-600 cursor-pointer" data-city={bcn.city_poi_id} onClick={handleInfoClick}>Plus d'infos</span>
                         </Popup>
                     </Marker>

--- a/client/src/components/map/DoneLayer.jsx
+++ b/client/src/components/map/DoneLayer.jsx
@@ -1,9 +1,7 @@
 import { useContext, useState, useEffect } from "react";
 import { UidContext } from "../AppContext";
 import { useDispatch } from "react-redux";
-import getColoredIcon from '../../utilities/getColoredIcon';
 import { LayerGroup } from "@monsonjeremy/react-leaflet";
-import { setPane } from "../../redux/actions/pane.actions";
 import {getAllBpfs} from '../../utilities/bpfRequests';
 
 import { Marker, Popup } from "@monsonjeremy/react-leaflet";
@@ -17,6 +15,33 @@ import iconMarkerCheckYellow from '../../img/icons/marker-check-yellow.svg';
 import iconMarkerCheckOrange from '../../img/icons/marker-check-orange.svg';
 // Colors of dpts
 import colors from '../../utilities/colors-dpts.json'
+
+// Gets a bcn or bpf and return the icon corresponding to his dpt
+export function getIcon (point) {
+        let iconUrl = iconMarkerCheckBlue
+
+        if (colors[point.city_departement] === "blue") {
+            iconUrl = iconMarkerCheckBlue;
+        } else if (colors[point.city_departement] === "yellow") {
+            iconUrl = iconMarkerCheckYellow
+        } else if (colors[point.city_departement] === "red") {
+            iconUrl = iconMarkerCheckRed
+        } else if (colors[point.city_departement] === "green") {
+            iconUrl = iconMarkerCheckGreen
+        } else if (colors[point.city_departement] === "orange") {
+            iconUrl = iconMarkerCheckOrange
+        } else {
+            iconUrl = iconMarkerCheck;
+        }
+
+        const icon = L.icon({
+            iconUrl,
+            iconSize: [30, 30],
+            iconAnchor: [15, 30]
+        })
+
+    return icon
+}
 
 /**
  * Displays all done bpfs
@@ -39,27 +64,7 @@ export default function DoneLayer(props) {
     return (
         <LayerGroup>
             {userBpfs.map(bpf => {
-                    let iconUrl = iconMarkerCheckBlue
-
-                    if (colors[bpf.city_departement] === "blue") {
-                        iconUrl = iconMarkerCheckBlue;
-                    } else if (colors[bpf.city_departement] === "yellow") {
-                        iconUrl = iconMarkerCheckYellow
-                    } else if (colors[bpf.city_departement] === "red") {
-                        iconUrl = iconMarkerCheckRed
-                    } else if (colors[bpf.city_departement] === "green") {
-                        iconUrl = iconMarkerCheckGreen
-                    } else if (colors[bpf.city_departement] === "orange") {
-                        iconUrl = iconMarkerCheckOrange
-                    } else {
-                        iconUrl = iconMarkerCheck;
-                    }
-
-                    const icon = L.icon({
-                        iconUrl,
-                        iconSize: [30, 30],
-                        iconAnchor: [15, 30]
-                    })
+                    const icon = getIcon(bpf);
 
                     return (
                         <Marker position={[bpf.city_lat, bpf.city_long]} icon={icon} key={bpf.bpf_id}>

--- a/client/src/components/map/MapControl.jsx
+++ b/client/src/components/map/MapControl.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useEffect } from 'react'
 import { useState } from 'react'
 
+// A component that generates a control for the map sidebar (checkbox and label + toggling dynamics)
 function MapControl({ name, toggling, defaultChecked }) {
     const [isToggled, setIsToggled] = useState(defaultChecked)
     // const [layer, setLayer] = useState(null)
@@ -14,11 +15,15 @@ function MapControl({ name, toggling, defaultChecked }) {
 
     const toggleLayer = (e) => {
         if (e.target.checked && !toggling.firstChild.firstChild.checked) {
+            console.log("checking")
             setIsToggled(true)
-            toggling.firstChild.firstChild.click()
+            toggling.firstChild.firstChild.checked = true
+            console.log(toggling.firstChild.firstChild)
         } else if (!e.target.checked && toggling.firstChild.firstChild.checked) {
+            console.log("unchecking")
             setIsToggled(false);
-            toggling.firstChild.firstChild.click()
+            toggling.firstChild.firstChild.checked = false
+            console.log(toggling.firstChild.firstChild)
         }
     }
 

--- a/client/src/components/map/MapControl.jsx
+++ b/client/src/components/map/MapControl.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { useEffect } from 'react'
-import { useState, forwardRef, useImperativeHandle } from 'react'
+import { useState, forwardRef } from 'react'
 
 // A component that generates a control for the map sidebar (checkbox and label + toggling dynamics)
 const MapControl = forwardRef(function MapControl ({ name, toggling, defaultChecked }, ref) {

--- a/client/src/components/map/MapControl.jsx
+++ b/client/src/components/map/MapControl.jsx
@@ -1,35 +1,24 @@
 import React from 'react'
 import { useEffect } from 'react'
-import { useState } from 'react'
+import { useState, forwardRef, useImperativeHandle } from 'react'
 
 // A component that generates a control for the map sidebar (checkbox and label + toggling dynamics)
-function MapControl({ name, toggling, defaultChecked }) {
+function MapControl ({ name, toggling, defaultChecked }, ref) {
     const [isToggled, setIsToggled] = useState(defaultChecked)
-    // const [layer, setLayer] = useState(null)
-
-    // useEffect(() => {
-    //     if (toggling) {
-    //         setLayer(toggling.firstChild.firstChild)
-    //     }
-    // }, [toggling])
 
     const toggleLayer = (e) => {
         if (e.target.checked && !toggling.firstChild.firstChild.checked) {
-            console.log("checking")
             setIsToggled(true)
-            toggling.firstChild.firstChild.checked = true
-            console.log(toggling.firstChild.firstChild)
+            toggling.firstChild.firstChild.click();
         } else if (!e.target.checked && toggling.firstChild.firstChild.checked) {
-            console.log("unchecking")
             setIsToggled(false);
-            toggling.firstChild.firstChild.checked = false
-            console.log(toggling.firstChild.firstChild)
+            toggling.firstChild.firstChild.click();
         }
     }
 
     return (
         <label className="block"><input type="checkbox" className="mr-2" onChange={toggleLayer} checked={isToggled} />{name}</label>
     )
-}
+};
 
 export default MapControl

--- a/client/src/components/map/MapControl.jsx
+++ b/client/src/components/map/MapControl.jsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 import { useState, forwardRef, useImperativeHandle } from 'react'
 
 // A component that generates a control for the map sidebar (checkbox and label + toggling dynamics)
-function MapControl ({ name, toggling, defaultChecked }, ref) {
+const MapControl = forwardRef(function MapControl ({ name, toggling, defaultChecked }, ref) {
     const [isToggled, setIsToggled] = useState(defaultChecked)
 
     const toggleLayer = (e) => {
@@ -17,8 +17,8 @@ function MapControl ({ name, toggling, defaultChecked }, ref) {
     }
 
     return (
-        <label className="block"><input type="checkbox" className="mr-2" onChange={toggleLayer} checked={isToggled} />{name}</label>
+        <label className="block"><input type="checkbox" className="mr-2" onChange={toggleLayer} checked={isToggled} ref={ref}/>{name}</label>
     )
-};
+});
 
 export default MapControl

--- a/client/src/components/map/SideControls.jsx
+++ b/client/src/components/map/SideControls.jsx
@@ -1,23 +1,26 @@
 import React, {useRef, useState} from 'react'
-import { useEffect } from 'react';
-import { AdjustmentsIcon, ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/outline"
+import {useEffect} from 'react';
+import {AdjustmentsIcon, ChevronDownIcon, ChevronUpIcon} from "@heroicons/react/outline"
 
 import MapControl from './MapControl';
 
 function Pills({handler, ref1, ref2}) {
     return (
-        <>
-            <button id="pill-bpf" onClick={handler} className="py-2 px-4 border-2 border-r-0 border-blue-400 rounded-l-full cursor-pointer pill-active" ref={ref1}>
+        <div>
+            <button id="pill-bpf" onClick={handler}
+                    className="py-2 px-4 border-2 border-r-0 border-blue-400 rounded-l-full cursor-pointer pill-active text-sm"
+                    ref={ref1}>
                 BPF
             </button>
-            <button id="pill-bcn" onClick={handler} className="py-2 px-4 border-2 border-blue-400 rounded-r-full cursor-pointer" ref={ref2}>
+            <button id="pill-bcn" onClick={handler}
+                    className="py-2 px-4 border-2 border-blue-400 rounded-r-full cursor-pointer text-sm" ref={ref2}>
                 BCN
             </button>
-        </>
+        </div>
     )
 }
 
-function SideControls({ map }) {
+function SideControls({map}) {
     // Masquer les contrôles par défaut des calques sur la carte
     useEffect(() => {
         const layers = document.querySelector(".leaflet-control-layers-overlays");
@@ -67,10 +70,6 @@ function SideControls({ map }) {
     const [doneDptsSurfacesCheckboxBCN, setDoneDptsSurfacesCheckboxBCN] = useState(null);
     const [doneBcnsCheckbox, setDoneBcnsCheckbox] = useState(null);
 
-    const groupBpfControls = [doneCheckbox, notDoneCheckbox, doneDptsSurfacesCheckbox, otherDptsSurfacesCheckbox];
-    const groupBcnControls = [doneDptsSurfacesCheckboxBCN, doneBcnsCheckbox]
-
-
     useEffect(() => {
         let overlay = document.querySelector(".leaflet-control-layers-overlays");
 
@@ -86,7 +85,7 @@ function SideControls({ map }) {
         }
     })
 
-    // Mode de la carte (BPf ou BCN)
+    // Mode de la carte (BPF ou BCN)
     const refPillBpf = useRef(null);
     const refPillBcn = useRef(null);
 
@@ -94,8 +93,45 @@ function SideControls({ map }) {
     const bcnControls = useRef(null);
     const [bpfControlsDisplay, setBpfControlsDisplay] = useState(true);
     const [bcnControlsDisplay, setBcnControlsDisplay] = useState(false);
+
+    const disableAllBpfsLayers = () => {
+        groupRefsBpfs.map(ref => {
+            if (ref.current.checked) {
+                ref.current.click();
+            }
+        })
+    }
+    const enableBpfsLayers = () => {
+        const refs = [refDoneBpfs, refOthersBpfs, refDoneDptsBpfs];
+        refs.map(ref => {
+            if (!ref.current.checked) {
+                ref.current.click();
+            }
+        })
+    }
+
+    const disableAllBcnsLayers = () => {
+        groupRefsBcns.map(ref => {
+            if (ref.current.checked) {
+                ref.current.click();
+            }
+        })
+    }
+
+    const enableBcnsLayers = () => {
+        groupRefsBcns.map(ref => {
+            if (!ref.current.checked) {
+                ref.current.click();
+            }
+        })
+    }
+
     const handlePills = (e) => {
         if (e.target.innerText === 'BPF') {
+            // Changement vers mode BPF
+            disableAllBcnsLayers();
+            enableBpfsLayers();
+
             refPillBcn.current.classList.remove('pill-active');
             refPillBpf.current.classList.add('pill-active');
 
@@ -103,39 +139,66 @@ function SideControls({ map }) {
             setBpfControlsDisplay(true);
 
         } else {
+            // Changement vers mode BCN
+            disableAllBpfsLayers();
+            enableBcnsLayers();
+
             refPillBpf.current.classList.remove('pill-active');
             refPillBcn.current.classList.add('pill-active');
 
             setBcnControlsDisplay(true);
             setBpfControlsDisplay(false);
+
         }
     }
+
+    // Refs to access the inputs of each control
+    const refDoneBpfs = useRef(null);
+    const refOthersBpfs = useRef(null);
+    const refDoneDptsBpfs = useRef(null);
+    const refOthersDptsBpfs = useRef(null);
+    const groupRefsBpfs = [refDoneBpfs, refOthersBpfs, refDoneDptsBpfs, refOthersDptsBpfs];
+
+    const refDoneBcns = useRef(null);
+    const refDoneDptsBcns = useRef(null);
+    const groupRefsBcns = [refDoneBcns, refDoneDptsBcns];
+
 
     return (
         <div className='md:col-span-2 lg:col-span-1 mt-4 md:ml-4 md:mt-8 space-y-4'>
             {/* Mobile menu toggler */}
-            <div className="visible md:hidden w-full py-2 font-bold text-center" onClick={e => setIsVisible(!isVisible)} aria-role="button">
+            <div className="visible md:hidden w-full py-2 font-bold text-center" onClick={e => setIsVisible(!isVisible)}
+                 aria-role="button">
                 Menu d'affichage&nbsp;
-                {isVisible ? <ChevronUpIcon className="icon-sm" /> : <ChevronDownIcon className="icon-sm" />}
+                {isVisible ? <ChevronUpIcon className="icon-sm"/> : <ChevronDownIcon className="icon-sm"/>}
             </div>
 
-            <div style={{ display: !isVisible && mobile ? "none" : "block" }} className="pb-4 md:pb-0 px-2 md:px-0">
-                <div className="text-xl lg:text-2xl">
+            <div style={{display: !isVisible && mobile ? "none" : "block"}} className="pb-4 md:pb-0 px-2 md:px-0">
+
+                {/* Pills (mode) */}
+                <div className="text-xl lg:text-2xl mb-2 flex-col">
+                    <h4>Mode d'affichage</h4>
                     <Pills ref1={refPillBpf} ref2={refPillBcn} handler={handlePills}/>
                 </div>
 
+
                 {/* Section des contrôles BPF */}
                 <div ref={bpfControls} style={{display: bpfControlsDisplay ? "block" : "none"}}>
-                    <div>
-                        <h4 className="text-xl lg:text-2xl">Sites</h4>
-                        <MapControl name="BPFs validés" defaultChecked={true} toggling={doneCheckbox}/>
-                        <MapControl name="BPFs non validés" defaultChecked={true} toggling={notDoneCheckbox} />
-                    </div>
 
                     <div>
-                        <h4 className="text-xl lg:text-2xl">Départements des BPF</h4>
-                        <MapControl name="Départements terminés (BPF)" defaultChecked={true} toggling={doneDptsSurfacesCheckbox} />
-                        <MapControl name="Départements non terminés (BPF)" defaultChecked={false} toggling={otherDptsSurfacesCheckbox} />
+                        <h4 className="text-lg lg:text-xl">Sites</h4>
+                        <MapControl name="BPFs validés" defaultChecked={true} toggling={doneCheckbox}
+                                    ref={refDoneBpfs}/>
+                        <MapControl name="BPFs non validés" defaultChecked={true} toggling={notDoneCheckbox}
+                                    ref={refOthersBpfs}/>
+                    </div>
+
+                    <div className="mt-2">
+                        <h4 className="text-lg lg:text-xl">Départements</h4>
+                        <MapControl name="Départements terminés (BPF)" defaultChecked={true}
+                                    toggling={doneDptsSurfacesCheckbox} ref={refDoneDptsBpfs}/>
+                        <MapControl name="Départements non terminés (BPF)" defaultChecked={false}
+                                    toggling={otherDptsSurfacesCheckbox} ref={refOthersDptsBpfs}/>
                     </div>
                 </div>
 
@@ -143,16 +206,18 @@ function SideControls({ map }) {
                 {/* Section des contrôles BCN */}
                 <div ref={bcnControls} style={{display: bcnControlsDisplay ? "block" : "none"}}>
                     <div>
-                        <h4 className="text-xl lg:text-2xl">Mode BCN</h4>
-                        <MapControl name="Départements terminés (BCN)" defaultChecked={false} toggling={doneDptsSurfacesCheckboxBCN}/>
-                        <MapControl name="BCNs validés" defaultChecked={false} toggling={doneBcnsCheckbox} />
+                        <h4 className="text-lg lg:text-xl">Mode BCN</h4>
+                        <MapControl name="Départements terminés (BCN)" defaultChecked={false}
+                                    toggling={doneDptsSurfacesCheckboxBCN} ref={refDoneDptsBcns}/>
+                        <MapControl name="BCNs validés" defaultChecked={false} toggling={doneBcnsCheckbox}
+                                    ref={refDoneBcns}/>
                     </div>
                 </div>
 
-                <div>
+                <div className="mt-4">
                     <h4 className="text-xl lg:text-2xl">Contours</h4>
-                    <MapControl name="Départements" defaultChecked={true} toggling={dptsShapesCheckbox} />
-                    <MapControl name="Provinces" defaultChecked={false} toggling={provincesShapesCheckbox} />
+                    <MapControl name="Départements" defaultChecked={true} toggling={dptsShapesCheckbox}/>
+                    <MapControl name="Provinces" defaultChecked={false} toggling={provincesShapesCheckbox}/>
                 </div>
 
                 <div className="space-y-2">

--- a/client/src/components/map/SideControls.jsx
+++ b/client/src/components/map/SideControls.jsx
@@ -1,6 +1,6 @@
 import React, {useRef, useState} from 'react'
 import {useEffect} from 'react';
-import {AdjustmentsIcon, ChevronDownIcon, ChevronUpIcon} from "@heroicons/react/outline"
+import {ChevronDownIcon, ChevronUpIcon} from "@heroicons/react/outline"
 
 import MapControl from './MapControl';
 

--- a/client/src/components/map/SideControls.jsx
+++ b/client/src/components/map/SideControls.jsx
@@ -5,7 +5,7 @@ import { AdjustmentsIcon, ChevronDownIcon, ChevronUpIcon } from "@heroicons/reac
 import MapControl from './MapControl';
 
 function SideControls({ map }) {
-    // Hide overlay layers toggle on map
+    // Masquer les contrôles par défaut des calques sur la carte
     useEffect(() => {
         const layers = document.querySelector(".leaflet-control-layers-overlays");
         const separator = document.querySelector(".leaflet-control-layers-separator");
@@ -15,9 +15,11 @@ function SideControls({ map }) {
         }
     })
 
+    // Comportement responsive
     const [isVisible, setIsVisible] = useState(false);
     const [mobile, setMobile] = useState(false);
 
+    // Défintion de l'appareil utilisateur : mobile ou bureau
     useEffect(() => {
         if (window.innerWidth < 724) {
             setMobile(true)
@@ -40,23 +42,28 @@ function SideControls({ map }) {
         map.flyTo([46.632, 1.852], 6)
     }
 
-    // Get the element for each checkbox in the leaflet overlay control
+    // Get the element for each checkbox in the leaflet overlay control WARNING : refer to the order of the layers on the map to know their indice in the childnodes list
     const [doneCheckbox, setDoneCheckbox] = useState(null)
     const [notDoneCheckbox, setNotDoneCheckbox] = useState(null)
     const [dptsShapesCheckbox, setDptsShapesCheckbox] = useState(null);
     const [provincesShapesCheckbox, setProvincesShapesCheckbox] = useState(null);
     const [doneDptsSurfacesCheckbox, setDoneDptsSurfacesCheckbox] = useState(null);
     const [otherDptsSurfacesCheckbox, setOtherDptsSurfacesCheckbox] = useState(null);
+    const [doneDptsSurfacesCheckboxBCN, setDoneDptsSurfacesCheckboxBCN] = useState(null);
+    const [doneBcnsCheckbox, setDoneBcnsCheckbox] = useState(null);
 
     useEffect(() => {
         let overlay = document.querySelector(".leaflet-control-layers-overlays");
-        if (overlay && overlay.childNodes.length == 6) {
+
+        if (overlay && overlay.childNodes.length == 8) {
             setDoneCheckbox(overlay.firstChild);
             setNotDoneCheckbox(overlay.childNodes[1]);
-            setDptsShapesCheckbox(overlay.childNodes[3]);
-            setProvincesShapesCheckbox(overlay.childNodes[2]);
-            setDoneDptsSurfacesCheckbox(overlay.childNodes[4]);
-            setOtherDptsSurfacesCheckbox(overlay.childNodes[5]);
+            setDptsShapesCheckbox(overlay.childNodes[4]);
+            setProvincesShapesCheckbox(overlay.childNodes[3]);
+            setDoneDptsSurfacesCheckbox(overlay.childNodes[5]);
+            setOtherDptsSurfacesCheckbox(overlay.childNodes[6]);
+            setDoneDptsSurfacesCheckboxBCN(overlay.childNodes[7]);
+            setDoneBcnsCheckbox(overlay.childNodes[2]);
         }
     })
 
@@ -85,6 +92,12 @@ function SideControls({ map }) {
                     <h4 className="text-xl lg:text-2xl">Départements des BPF</h4>
                     <MapControl name="Départements terminés (BPF)" defaultChecked={true} toggling={doneDptsSurfacesCheckbox} />
                     <MapControl name="Départements non terminés (BPF)" defaultChecked={false} toggling={otherDptsSurfacesCheckbox} />
+                </div>
+
+                <div>
+                    <h4 className="text-xl lg:text-2xl">Mode BCN</h4>
+                    <MapControl name="Départements terminés (BCN)" defaultChecked={false} toggling={doneDptsSurfacesCheckboxBCN}/>
+                    <MapControl name="BCNs validés" defaultChecked={false} toggling={doneBcnsCheckbox} />
                 </div>
 
                 <div className="space-y-2">

--- a/client/src/components/map/SideControls.jsx
+++ b/client/src/components/map/SideControls.jsx
@@ -1,8 +1,21 @@
-import React, { useState } from 'react'
+import React, {useRef, useState} from 'react'
 import { useEffect } from 'react';
 import { AdjustmentsIcon, ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/outline"
 
 import MapControl from './MapControl';
+
+function Pills({handler, ref1, ref2}) {
+    return (
+        <>
+            <button id="pill-bpf" onClick={handler} className="py-2 px-4 border-2 border-r-0 border-blue-400 rounded-l-full cursor-pointer pill-active" ref={ref1}>
+                BPF
+            </button>
+            <button id="pill-bcn" onClick={handler} className="py-2 px-4 border-2 border-blue-400 rounded-r-full cursor-pointer" ref={ref2}>
+                BCN
+            </button>
+        </>
+    )
+}
 
 function SideControls({ map }) {
     // Masquer les contrôles par défaut des calques sur la carte
@@ -35,6 +48,7 @@ function SideControls({ map }) {
         })
     }, [])
 
+    // Déplacements sur la carte
     const flyToLaReunion = () => {
         map.flyTo([-21.1351121, 55.2471124], 10)
     }
@@ -42,7 +56,8 @@ function SideControls({ map }) {
         map.flyTo([46.632, 1.852], 6)
     }
 
-    // Get the element for each checkbox in the leaflet overlay control WARNING : refer to the order of the layers on the map to know their indice in the childnodes list
+    // Controls
+    // Checkboxes of the Leaflet Layers Dialog WARNING : refer to the order of the layers on the map to know their indice in the childnodes list
     const [doneCheckbox, setDoneCheckbox] = useState(null)
     const [notDoneCheckbox, setNotDoneCheckbox] = useState(null)
     const [dptsShapesCheckbox, setDptsShapesCheckbox] = useState(null);
@@ -51,6 +66,10 @@ function SideControls({ map }) {
     const [otherDptsSurfacesCheckbox, setOtherDptsSurfacesCheckbox] = useState(null);
     const [doneDptsSurfacesCheckboxBCN, setDoneDptsSurfacesCheckboxBCN] = useState(null);
     const [doneBcnsCheckbox, setDoneBcnsCheckbox] = useState(null);
+
+    const groupBpfControls = [doneCheckbox, notDoneCheckbox, doneDptsSurfacesCheckbox, otherDptsSurfacesCheckbox];
+    const groupBcnControls = [doneDptsSurfacesCheckboxBCN, doneBcnsCheckbox]
+
 
     useEffect(() => {
         let overlay = document.querySelector(".leaflet-control-layers-overlays");
@@ -67,6 +86,31 @@ function SideControls({ map }) {
         }
     })
 
+    // Mode de la carte (BPf ou BCN)
+    const refPillBpf = useRef(null);
+    const refPillBcn = useRef(null);
+
+    const bpfControls = useRef(null);
+    const bcnControls = useRef(null);
+    const [bpfControlsDisplay, setBpfControlsDisplay] = useState(true);
+    const [bcnControlsDisplay, setBcnControlsDisplay] = useState(false);
+    const handlePills = (e) => {
+        if (e.target.innerText === 'BPF') {
+            refPillBcn.current.classList.remove('pill-active');
+            refPillBpf.current.classList.add('pill-active');
+
+            setBcnControlsDisplay(false);
+            setBpfControlsDisplay(true);
+
+        } else {
+            refPillBpf.current.classList.remove('pill-active');
+            refPillBcn.current.classList.add('pill-active');
+
+            setBcnControlsDisplay(true);
+            setBpfControlsDisplay(false);
+        }
+    }
+
     return (
         <div className='md:col-span-2 lg:col-span-1 mt-4 md:ml-4 md:mt-8 space-y-4'>
             {/* Mobile menu toggler */}
@@ -76,28 +120,39 @@ function SideControls({ map }) {
             </div>
 
             <div style={{ display: !isVisible && mobile ? "none" : "block" }} className="pb-4 md:pb-0 px-2 md:px-0">
-                <div>
-                    <h4 className="text-xl lg:text-2xl">Sites</h4>
-                    <MapControl name="BPFs validés" defaultChecked={true} toggling={doneCheckbox} />
-                    <MapControl name="BPFs non validés" defaultChecked={true} toggling={notDoneCheckbox} />
+                <div className="text-xl lg:text-2xl">
+                    <Pills ref1={refPillBpf} ref2={refPillBcn} handler={handlePills}/>
+                </div>
+
+                {/* Section des contrôles BPF */}
+                <div ref={bpfControls} style={{display: bpfControlsDisplay ? "block" : "none"}}>
+                    <div>
+                        <h4 className="text-xl lg:text-2xl">Sites</h4>
+                        <MapControl name="BPFs validés" defaultChecked={true} toggling={doneCheckbox}/>
+                        <MapControl name="BPFs non validés" defaultChecked={true} toggling={notDoneCheckbox} />
+                    </div>
+
+                    <div>
+                        <h4 className="text-xl lg:text-2xl">Départements des BPF</h4>
+                        <MapControl name="Départements terminés (BPF)" defaultChecked={true} toggling={doneDptsSurfacesCheckbox} />
+                        <MapControl name="Départements non terminés (BPF)" defaultChecked={false} toggling={otherDptsSurfacesCheckbox} />
+                    </div>
+                </div>
+
+
+                {/* Section des contrôles BCN */}
+                <div ref={bcnControls} style={{display: bcnControlsDisplay ? "block" : "none"}}>
+                    <div>
+                        <h4 className="text-xl lg:text-2xl">Mode BCN</h4>
+                        <MapControl name="Départements terminés (BCN)" defaultChecked={false} toggling={doneDptsSurfacesCheckboxBCN}/>
+                        <MapControl name="BCNs validés" defaultChecked={false} toggling={doneBcnsCheckbox} />
+                    </div>
                 </div>
 
                 <div>
                     <h4 className="text-xl lg:text-2xl">Contours</h4>
                     <MapControl name="Départements" defaultChecked={true} toggling={dptsShapesCheckbox} />
                     <MapControl name="Provinces" defaultChecked={false} toggling={provincesShapesCheckbox} />
-                </div>
-
-                <div>
-                    <h4 className="text-xl lg:text-2xl">Départements des BPF</h4>
-                    <MapControl name="Départements terminés (BPF)" defaultChecked={true} toggling={doneDptsSurfacesCheckbox} />
-                    <MapControl name="Départements non terminés (BPF)" defaultChecked={false} toggling={otherDptsSurfacesCheckbox} />
-                </div>
-
-                <div>
-                    <h4 className="text-xl lg:text-2xl">Mode BCN</h4>
-                    <MapControl name="Départements terminés (BCN)" defaultChecked={false} toggling={doneDptsSurfacesCheckboxBCN}/>
-                    <MapControl name="BCNs validés" defaultChecked={false} toggling={doneBcnsCheckbox} />
                 </div>
 
                 <div className="space-y-2">

--- a/client/src/pages/Map.jsx
+++ b/client/src/pages/Map.jsx
@@ -1,6 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react'
-import { useContext } from 'react'
-import { UidContext } from '../components/AppContext'
+import React, { useEffect, useState } from 'react'
 
 // Map components
 import { MapContainer, TileLayer, Marker, Popup, useMap, LayersControl, GeoJSON, ZoomControl, LayerGroup } from '@monsonjeremy/react-leaflet'
@@ -34,7 +32,6 @@ import DoneBcnsLayer from "../components/map/DoneBcnsLayer";
  * Container of the map
  */
 function MapContainerBpf() {
-    const uid = useContext(UidContext);
     const dispatch = useDispatch();
 
     // Don't display banner and footer

--- a/client/src/pages/Map.jsx
+++ b/client/src/pages/Map.jsx
@@ -28,6 +28,7 @@ import MapPane from '../components/MapPane'
 import DoneLayer from '../components/map/DoneLayer'
 import CitiesLayer from '../components/map/CitiesLayer'
 import { useDispatch } from 'react-redux'
+import DoneBcnsLayer from "../components/map/DoneBcnsLayer";
 
 /**
  * Container of the map
@@ -87,7 +88,7 @@ function MapContainerBpf() {
                         />
                     </LayersControl.BaseLayer>
 
-                    {/* Marker Layers */}
+                    {/* MARKER LAYERS */}
                     {/* Done BPF layer */}
                     <LayersControl.Overlay name="Mes BPF" checked>
                         <DoneLayer />
@@ -98,6 +99,13 @@ function MapContainerBpf() {
                         <CitiesLayer />
                     </LayersControl.Overlay>
 
+                    {/*Done BCNs  layer*/}
+                    <LayersControl.Overlay name="BCN faits">
+                        <DoneBcnsLayer/>
+                    </LayersControl.Overlay>
+
+
+                    {/* MAP SHAPES */}
                     {/* Provinces */}
                     <LayersControl.Overlay name="Contours des provinces">
                         <ProvincesLayer />
@@ -114,6 +122,11 @@ function MapContainerBpf() {
                     </LayersControl.Overlay>
                     <LayersControl.Overlay name="Coloration des départements non terminés">
                         <NotDoneDptsLayer />
+                    </LayersControl.Overlay>
+
+                    {/* Départements des BCN terminés */}
+                    <LayersControl.Overlay name="Coloration des départements des BCN terminés">
+                        <BcnLayerDoneDpts/>
                     </LayersControl.Overlay>
 
                 </LayersControl>
@@ -223,6 +236,24 @@ function NotDoneDptsLayer() {
     return (
         <LayerGroup>
             {doneBpfs.length != 0 && notDoneDpts.map(dpt => <GeoJSON key={dpt} data={dptsShapes.features.filter(a => a.properties.code == dpt)[0]} style={{ fill: true, fillOpacity: 0.5, color: "red", weight: 0 }} />)}
+        </LayerGroup>
+    )
+}
+
+// LAYERS FOR BCNS
+function BcnLayerDoneDpts() {
+    // Get codes of done dpts into an array
+    let doneBcns = useSelector(state => state.bcns);
+    let doneDpts = [];
+
+    doneBcns.map(bcn => {
+        doneDpts.push(bcn.city_departement)
+    })
+
+//     Display these dpts
+    return (
+        <LayerGroup>
+            {doneDpts.map(dpt => <GeoJSON key={dpt} data={dptsShapes.features.filter(a => a.properties.code == dpt)[0]} style={{ fill: true, fillOpacity: 0.5, color: "green", weight: 0 }} />)}
         </LayerGroup>
     )
 }


### PR DESCRIPTION
New features on the map page : it's now possible to view done departements of BCN and done cities of BCN.
This works with a switch which permits to chose between two display modes : BPF and BCN.
The BPF mode didn't change.
When switching of mode, the system auto activates layers which refers to the corresponding mode, and desactivates the others layers.

![BCN Mode](https://github.com/DamienSn/BpfMgr/assets/70515684/3c5e3373-ed11-4aa9-ba4c-fbced01f9d99)
![BPF Mode](https://github.com/DamienSn/BpfMgr/assets/70515684/d0b65230-018e-43b9-b151-7cd2e1290c9a)

