### PR TITLE
v2.0.1 - Corrections minimes

### DIFF
--- a/client/src/components/map/CitiesOldLayer.jsx
+++ b/client/src/components/map/CitiesOldLayer.jsx
@@ -45,7 +45,7 @@ export default function CitiesOldLayer(props) {
                     return (
                         <Marker position={[city.city_lat, city.city_long]} key={city.city_poi_id} icon={getColoredIcon(city.city_departement, city.city_is_old_new_id)}>
                             <Popup>
-                                {`${city.city_name} (${city.city_departement})`}<br />
+                                {`Ancien BPF - ${city.city_name} (${city.city_departement})`}<br />
                                 Non validé<br />
                                 <span className="underline text-blue-600 cursor-pointer" data-city={city.city_poi_id} onClick={handleInfoClick}>Plus d'infos & Validation</span>
                             </Popup>

--- a/client/src/components/map/DoneLayer.jsx
+++ b/client/src/components/map/DoneLayer.jsx
@@ -58,7 +58,7 @@ export default function DoneLayer(props) {
                     return (
                         <Marker position={[bpf.city_lat, bpf.city_long]} icon={icon} key={bpf.bpf_id}>
                             <Popup>
-                                {`Ancien BPF - ${bpf.city_name} (${bpf.city_departement})`}<br />
+                                {`${bpf.city_name} (${bpf.city_departement})`}<br />
                                 Validé le : {new Date(bpf.bpf_date).toLocaleDateString()}<br/>
                                 <span className="underline text-blue-600 cursor-pointer" data-city={bpf.city_poi_id} onClick={handleInfoClick}>Plus d'infos</span>
                             </Popup>


### PR DESCRIPTION
Correction d'une erreur sur le texte des popups de la carte :
- Les BPFS actuels validés s'affichaient avec le texte "Ancien BPF"
- Les anciens BPFs non validés ne s'affichaient pas avec le texte "Ancien BPF"